### PR TITLE
Added a namespace to the android manifest file for new graddle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.fortune.openpay_bbva'
     compileSdkVersion 31
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.fortune.openpay_bbva">
+  >
 </manifest>


### PR DESCRIPTION
Description of the Change
This Pull Request explicitly adds a namespace to the library's build.gradle file to comply with the requirements introduced in Android Gradle Plugin (AGP) 8.0.0. This update ensures the library is compatible with recent AGP versions, preventing build errors related to the missing namespace.

Context
As of AGP 8.0.0, the namespace attribute has become mandatory and is no longer inferred automatically from the package attribute in the AndroidManifest.xml. This change addresses the issues reported when using the library in projects that depend on AGP 8.0.0 or higher.

Changes Made
Added the namespace attribute in the library's build.gradle file.
The value of namespace has been kept consistent with the package attribute specified in the AndroidManifest.xml.
Benefits
The library is now fully compatible with AGP 8.0.0 and later.
Build errors related to the missing namespace are resolved.
Testing
The solution was tested in a project using AGP 8.0.0 and Gradle 7.5, confirming that the build completes successfully.
Please review the change and let me know if any additional adjustments or information is needed.